### PR TITLE
Register puppet and puppet_server as provisioners

### DIFF
--- a/lib/config_builder/model/provisioner/puppet.rb
+++ b/lib/config_builder/model/provisioner/puppet.rb
@@ -1,5 +1,5 @@
 # @see http://docs.vagrantup.com/v2/provisioning/puppet_apply.html
-class ConfigBuilder::Model::Provisioner::Puppet
+class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
 
   # @!attribute [rw] manifests_path
   #   @return [String] The path to the puppet manifests.
@@ -20,4 +20,18 @@ class ConfigBuilder::Model::Provisioner::Puppet
   # @!attribute [rw] options
   #   @return [String] An arbitrary set of arguments for the `puppet` command
   attr_accessor :options
+
+  def to_proc
+    Proc.new do |vm_config|
+      vm_config.provision :puppet do |puppet_config|
+        puppet_config.manifests_path = attr(:manifests_path) if attr(:manifests_path)
+        puppet_config.manifest_file  = attr(:manifest_file)  if attr(:manifest_file)
+        puppet_config.module_path    = attr(:module_path)    if attr(:module_path)
+        puppet_config.facter         = attr(:facter)         if attr(:facter)
+        puppet_config.options        = attr(:options)        if attr(:options)
+      end
+    end
+  end
+
+  ConfigBuilder::Model::Provisioner.register('puppet', self)
 end

--- a/lib/config_builder/model/provisioner/puppet_server.rb
+++ b/lib/config_builder/model/provisioner/puppet_server.rb
@@ -1,5 +1,5 @@
 # @see http://docs.vagrantup.com/v2/provisioning/puppet_agent.html
-class ConfigBuilder::Model::Provisioner::PuppetServer
+class ConfigBuilder::Model::Provisioner::PuppetServer < ConfigBuilder::Model::Base
 
   # @!attribute [rw] puppet_server
   #   @return [String]
@@ -12,4 +12,16 @@ class ConfigBuilder::Model::Provisioner::PuppetServer
   # @!attribute [rw] options
   #   @return [String]
   attr_accessor :options
+
+  def to_proc
+    Proc.new do |vm_config|
+      vm_config.provision :puppet_server do |puppet_config|
+        puppet_config.puppet_server = attr(:puppet_server)  if attr(:puppet_server)
+        puppet_config.node_name     = attr(:node_name)      if attr(:node_name)
+        puppet_config.options       = attr(:options)        if attr(:options)
+      end
+    end
+  end
+
+  ConfigBuilder::Model::Provisioner.register('puppet_server', self)
 end


### PR DESCRIPTION
For these two models:
- Inherit from `ConfigBuilder::Model::Base`
- Implement `to_proc`
- Call `ConfigBuilder::Model::Provisioner.register`
