### PR TITLE
Add support for vagrant-windows

### DIFF
--- a/lib/config_builder/filter/roles.rb
+++ b/lib/config_builder/filter/roles.rb
@@ -126,6 +126,7 @@ class ConfigBuilder::Filter::Roles
       forwarded_ports
       private_networks
       public_networks
+      guest
     ]
 
     array_keys.each do |key|

--- a/lib/config_builder/model/vm.rb
+++ b/lib/config_builder/model/vm.rb
@@ -66,6 +66,10 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
   #   @return [String] The name of the Vagrant box to instantiate for this VM
   def_model_attribute :box
 
+  # @!attribute [rw] guest
+  #   @return [String] The guest type to use for this VM
+  def_model_attribute :guest
+
   # @!attribute [rw] box_url
   #   @return [String] The source URL for the Vagrant box associated with this VM
   def_model_attribute :box
@@ -95,6 +99,7 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
         vm_config.box = attr(:box) if defined? attr(:box)
         vm_config.box_url = attr(:box_url) if defined? attr(:box_url)
         vm_config.hostname = attr(:hostname) if defined? attr(:hostname)
+        vm_config.guest = attr(:guest) if defined? attr(:guest)
 
         eval_models(vm_config)
       end


### PR DESCRIPTION
The bare minimum configuration necessary to make config_builder compatible with vagrant-windows is to allow a specification of "guest". E.g.

```
- name: "server2008r2a"
  box: "windows-server-2008-r2-x64-v2"
  guest: windows
```
