### PR TITLE
Idea for plugin config

### DIFF
--- a/lib/config_builder/model/plugin_entry.rb
+++ b/lib/config_builder/model/plugin_entry.rb
@@ -1,0 +1,25 @@
+# Vagrant shared folder model.
+#
+# @see http://docs.vagrantup.com/v2/plugins/index.html
+class ConfigBuilder::Model::PluginEntry < ConfigBuilder::Model::Base
+
+  # @!attribute [rw] plugin
+  #   @return [String] The name of the Vagrant plugin to address
+  def_model_attribute :plugin
+
+  # @!attribute [rw] config_attribute
+  #   @return [String] The name of the attribute to use for configuring the plugin
+  def_model_attribute :config_attribute
+
+  # @!attribute [rw] settings
+  #   @return [Hash<Symbol, Object>] List with settings and their value for configuring the plugin 
+  def_model_attribute :settings
+
+  def to_proc
+    Proc.new do |global_config|
+      if Vagrant.has_plugin?(attr(:plugin)) then
+        global_config.send(attr(:config_attribute), attr(:settings))
+      end
+    end
+  end
+end

--- a/lib/config_builder/model/vm.rb
+++ b/lib/config_builder/model/vm.rb
@@ -73,6 +73,15 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
   #
   def_model_delegator :synced_folders
 
+  # @!attribute [rw] plugins
+  #   @return [Array<Hash<Symbol, Object>>]
+  #   @example
+  #     >> config.plugins
+  #     => [
+  #           {:plugin => 'vagrant-vbguest', :config_attribute => 'vbguest', {:auto_update => false, }},
+  #        ]
+  def_model_delegator :plugins
+
   # @!attribute [rw] box
   #   @return [String] The name of the Vagrant box to instantiate for this VM
   def_model_attribute :box
@@ -105,6 +114,7 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
       :forwarded_ports  => [],
       :private_networks => [],
       :synced_folders   => [],
+      :plugins          => [],
     }
   end
 
@@ -122,6 +132,7 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
 
         eval_models(vm_config)
       end
+      eval_plugins(global_config)
     end
   end
 
@@ -166,6 +177,13 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
     attr(:synced_folders).each do |hash|
       f = ConfigBuilder::Model::SyncedFolder.new_from_hash(hash)
       f.call(vm_config)
+    end
+  end
+
+  def eval_plugins(global_config)
+    attr(:plugins).each do |hash|
+      f = ConfigBuilder::Model::PluginEntry.new_from_hash(hash)
+      f.call(global_config)
     end
   end
 end


### PR DESCRIPTION
From within the roles.yml I'd like to be able to configure specific plugins. E.g. in Vagrantfile:

```
if Vagrant.has_plugin?("vagrant-vbguest") then
  config.vbguest.auto_update = false
end
```

In the roles.yml this could translate to something like e.g.:

```

---
  some-box:
    private_networks:
      - {ip: '0.0.0.0', auto_network: true}
    forwarded_ports:
      - {guest: 2375, host: 2375, auto_correct: true}
    provider:
      type: virtualbox
      check_guest_additions: false
      functional_vboxsf: false
      customize:
        - [modifyvm, !ruby/sym id, '--memory', 256]
        - [modifyvm, !ruby/sym id, '--natdnshostresolver1', 'on']
        - [modifyvm, !ruby/sym id, '--natdnsproxy1', 'on']
        - [modifyvm, !ruby/sym id, '--uart1', '0x3F8', '4']
    provisioners:
      - {type: hosts}
    plugins:
      - {plugin: vagrant-vbguest, config_attribute: vbguest, { auto_update: false } }
```

This pull request contains an untested (!) idea of what I'm trying to achieve, however my Ruby coding stinks... 

Would this be achievable?
