### PR TITLE
Add vmware workstation support.

### DIFF
--- a/lib/config_builder/model.rb
+++ b/lib/config_builder/model.rb
@@ -38,7 +38,9 @@ module ConfigBuilder
       end
 
       require 'config_builder/model/provider/virtualbox'
+      require 'config_builder/model/provider/vmware'
       require 'config_builder/model/provider/vmware_fusion'
+      require 'config_builder/model/provider/vmware_workstation'
     end
 
     module Provisioner

--- a/lib/config_builder/model/provider/vmware.rb
+++ b/lib/config_builder/model/provider/vmware.rb
@@ -1,0 +1,40 @@
+# @see http://docs.vagrantup.com/v2/vmware/configuration.html
+class ConfigBuilder::Model::Provider::VMware < ConfigBuilder::Model::Base
+
+  # @!attribute [rw] vmx
+  #   @return [Hash<String, String>] A hash of VMX options for the given VM
+  #   @example
+  #     model.vmx = {
+  #       'memsize'  => '1024',
+  #       'numvcpus' => '2',
+  #     }
+  def_model_attribute :vmx
+
+  # @!attribute [rw] gui
+  #   @return [Boolean] Whether the GUI should be launched when the VM is created
+  def_model_attribute :gui
+
+  def initialize
+    @defaults = {
+      :gui => false,
+      :vmx => {},
+    }
+
+    @providers ||= %w[vmware_fusion vmware_workstation]
+  end
+
+  def to_proc
+    Proc.new do |vm_config|
+      @providers.each do |vmware_provider|
+        vm_config.provider vmware_provider do |config|
+          config.gui = attr(:gui)
+          attr(:vmx).each_pair do |key, value|
+            config.vmx[key] = value
+          end
+        end
+      end
+    end
+  end
+
+  ConfigBuilder::Model::Provider.register('vmware', self)
+end

--- a/lib/config_builder/model/provider/vmware_fusion.rb
+++ b/lib/config_builder/model/provider/vmware_fusion.rb
@@ -1,35 +1,7 @@
-# @see http://docs.vagrantup.com/v2/vmware/configuration.html
-class ConfigBuilder::Model::Provider::VMwareFusion < ConfigBuilder::Model::Base
-
-  # @!attribute [rw] vmx
-  #   @return [Hash<String, String>] A hash of VMX options for the given VM
-  #   @example
-  #     model.vmx = {
-  #       'memsize'  => '1024',
-  #       'numvcpus' => '2',
-  #     }
-  def_model_attribute :vmx
-
-  # @!attribute [rw] gui
-  #   @return [Boolean] Whether the GUI should be launched when the VM is created
-  def_model_attribute :gui
-
+class ConfigBuilder::Model::Provider::VMwareFusion < ConfigBuilder::Model::Provider::VMware
   def initialize
-    @defaults = {
-      :gui => false,
-      :vmx => {},
-    }
-  end
-
-  def to_proc
-    Proc.new do |vm_config|
-      vm_config.provider 'vmware_fusion' do |fusion_config|
-        fusion_config.gui = attr(:gui)
-        attr(:vmx).each_pair do |key, value|
-          fusion_config.vmx[key] = value
-        end
-      end
-    end
+    @providers = %w[vmware_fusion]
+    super
   end
 
   ConfigBuilder::Model::Provider.register('vmware_fusion', self)

--- a/lib/config_builder/model/provider/vmware_workstation.rb
+++ b/lib/config_builder/model/provider/vmware_workstation.rb
@@ -1,0 +1,8 @@
+class ConfigBuilder::Model::Provider::VMwareWorkstation < ConfigBuilder::Model::Provider::VMware
+  def initialize
+    @providers = %w[vmware_workstation]
+    super
+  end
+
+  ConfigBuilder::Model::Provider.register('vmware_workstation', self)
+end


### PR DESCRIPTION
Use a generic vmware model to support fusion and workstation. A generic
vmware provider will pick the appropriate provider. A warning message is
generated regarding missing plugin if vmware provider is requested and
neither fusion or workstation plugin is loaded.
