### PR TITLE
Dynamic YAML config by processing ERB first 

### DIFF
--- a/lib/config_builder/loader.rb
+++ b/lib/config_builder/loader.rb
@@ -18,5 +18,6 @@ module ConfigBuilder
     end
 
     require 'config_builder/loader/yaml'
+    require 'config_builder/loader/yaml_erb'
   end
 end

--- a/lib/config_builder/loader/yaml.rb
+++ b/lib/config_builder/loader/yaml.rb
@@ -22,7 +22,7 @@ class ConfigBuilder::Loader::YAML
     rv = {}
 
     files.each do |file|
-      contents = ::YAML.load_file(file)
+      contents = yamlfile(file)
       if contents.is_a? Hash
         rv = DeepMerge::deep_merge!(contents, rv, {:preserve_unmergables => false})
       end

--- a/lib/config_builder/loader/yaml_erb.rb
+++ b/lib/config_builder/loader/yaml_erb.rb
@@ -1,0 +1,24 @@
+require 'erb'
+
+class ConfigBuilder::Loader::YAML_ERB < ConfigBuilder::Loader::YAML
+
+  # Load configuration from a YAML file with ERB interpolation first
+  #
+  # @param file_path [String]
+  #
+  # @example the following config file will be processed by ERB first so it can
+  # determine whether to use the environment variable 'VAGRANT_MANIFEST' or the
+  # default value 'init.pp' for the puppet manifest file.
+  #
+  # ---
+  #   provisioner:
+  #     - type: puppet
+  #       manifest_file: <%= ENV['VAGRANT_MANIFEST'] || 'init.pp' >
+  #
+  # @return [Hash]
+  def yamlfile(file_path)
+    ::YAML.load(::ERB.new(File.read(file_path)).result)
+  end
+
+  ConfigBuilder::Loader.register(:yaml_erb, self)
+end


### PR DESCRIPTION
The yaml configuration files are processed by ERB first. This allows
slightly more dynamic configs, such as support of environment variables
for vagrant vm/provisioner settings:

``` yaml

---
  provisioner:
    - type: puppet
      manifest_file: <%= ENV['VAGRANT_MANIFEST'] || 'init.pp' >
```
