### PR TITLE
Run option support

### DIFF
--- a/lib/config_builder/model/provisioner/file.rb
+++ b/lib/config_builder/model/provisioner/file.rb
@@ -11,9 +11,19 @@ class ConfigBuilder::Model::Provisioner::File < ConfigBuilder::Model::Base
   #     determined by running vagrant ssh-config, and defaults to "vagrant".
   def_model_attribute :destination
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  attr_accessor :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :file do |file_config|
+      vm_config.provision :file, run: attr(:run) do |file_config|
         with_attr(:source)        { |val| file_config.source = val }
         with_attr(:destination)   { |val| file_config.destination = val }
       end

--- a/lib/config_builder/model/provisioner/file.rb
+++ b/lib/config_builder/model/provisioner/file.rb
@@ -11,20 +11,9 @@ class ConfigBuilder::Model::Provisioner::File < ConfigBuilder::Model::Base
   #     determined by running vagrant ssh-config, and defaults to "vagrant".
   def_model_attribute :destination
 
-
-  # @!attribute [rw] run
-  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
-  def_model_attribute :run
-
-  def initialize
-    @defaults = {
-     :run => 'once',
-    }
-  end
-
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :file, run: attr(:run) do |file_config|
+      vm_config.provision :file do |file_config|
         with_attr(:source)        { |val| file_config.source = val }
         with_attr(:destination)   { |val| file_config.destination = val }
       end

--- a/lib/config_builder/model/provisioner/file.rb
+++ b/lib/config_builder/model/provisioner/file.rb
@@ -11,9 +11,20 @@ class ConfigBuilder::Model::Provisioner::File < ConfigBuilder::Model::Base
   #     determined by running vagrant ssh-config, and defaults to "vagrant".
   def_model_attribute :destination
 
+
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  def_model_attribute :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :file do |file_config|
+      vm_config.provision :file, run: attr(:run) do |file_config|
         with_attr(:source)        { |val| file_config.source = val }
         with_attr(:destination)   { |val| file_config.destination = val }
       end

--- a/lib/config_builder/model/provisioner/puppet.rb
+++ b/lib/config_builder/model/provisioner/puppet.rb
@@ -21,9 +21,19 @@ class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
   #   @return [String] An arbitrary set of arguments for the `puppet` command
   attr_accessor :options
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  attribute_accessor :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :puppet do |puppet_config|
+      vm_config.provision :puppet, run: attr(:run) do |puppet_config|
         with_attr(:manifests_path) { |val| puppet_config.manifests_path = val }
         with_attr(:manifest_file)  { |val| puppet_config.manifest_file  = val }
         with_attr(:module_path)    { |val| puppet_config.module_path    = val }

--- a/lib/config_builder/model/provisioner/puppet.rb
+++ b/lib/config_builder/model/provisioner/puppet.rb
@@ -21,19 +21,9 @@ class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
   #   @return [String] An arbitrary set of arguments for the `puppet` command
   attr_accessor :options
 
-  # @!attribute [rw] run
-  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
-  attribute_accessor :run
-
-  def initialize
-    @defaults = {
-     :run => 'once',
-    }
-  end
-
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :puppet, run: attr(:run) do |puppet_config|
+      vm_config.provision :puppet do |puppet_config|
         with_attr(:manifests_path) { |val| puppet_config.manifests_path = val }
         with_attr(:manifest_file)  { |val| puppet_config.manifest_file  = val }
         with_attr(:module_path)    { |val| puppet_config.module_path    = val }

--- a/lib/config_builder/model/provisioner/puppet.rb
+++ b/lib/config_builder/model/provisioner/puppet.rb
@@ -21,9 +21,19 @@ class ConfigBuilder::Model::Provisioner::Puppet < ConfigBuilder::Model::Base
   #   @return [String] An arbitrary set of arguments for the `puppet` command
   attr_accessor :options
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  attr_accessor :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :puppet do |puppet_config|
+      vm_config.provision :puppet, run: attr(:run) do |puppet_config|
         with_attr(:manifests_path) { |val| puppet_config.manifests_path = val }
         with_attr(:manifest_file)  { |val| puppet_config.manifest_file  = val }
         with_attr(:module_path)    { |val| puppet_config.module_path    = val }

--- a/lib/config_builder/model/provisioner/puppet_server.rb
+++ b/lib/config_builder/model/provisioner/puppet_server.rb
@@ -13,9 +13,19 @@ class ConfigBuilder::Model::Provisioner::PuppetServer < ConfigBuilder::Model::Ba
   #   @return [String]
   attr_accessor :options
 
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  attr__accessor :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :puppet_server do |puppet_config|
+      vm_config.provision :puppet_server, run: attr(:run) do |puppet_config|
         with_attr(:puppet_server) { |val| puppet_config.puppet_server = val }
         with_attr(:node_name)     { |val| puppet_config.node_name     = val }
         with_attr(:options)       { |val| puppet_config.options       = val }

--- a/lib/config_builder/model/provisioner/shell.rb
+++ b/lib/config_builder/model/provisioner/shell.rb
@@ -13,9 +13,20 @@ class ConfigBuilder::Model::Provisioner::Shell < ConfigBuilder::Model::Base
   #   @return [String] A string acting as an argument vector to the command.
   def_model_attribute :args
 
+
+  # @!attribute [rw] run
+  #   @return [String] Defaults to not set. If set to 'always' will cause provisioner to always run.
+  def_model_attribute :run
+
+  def initialize
+    @defaults = {
+     :run => 'once',
+    }
+  end
+
   def to_proc
     Proc.new do |vm_config|
-      vm_config.provision :shell do |shell_config|
+      vm_config.provision :shell, run: attr(:run) do |shell_config|
         with_attr(:inline) { |val| shell_config.inline = val }
         with_attr(:path)   { |val| shell_config.path   = val }
         with_attr(:args)   { |val| shell_config.args   = val }


### PR DESCRIPTION
This adds support for the run option.

Sets it to default to once, like vagrant does, and has one commit per provisioner.