### PR TITLE
Roles no longer preempt specific VM configuration

### DIFF
--- a/spec/config_builder/filter/roles_spec.rb
+++ b/spec/config_builder/filter/roles_spec.rb
@@ -40,7 +40,10 @@ describe ConfigBuilder::Filter::Roles do
         'private_networks' => [
           {'ip' => '1.2.3.4'}
         ]
-      }
+      },
+      'windows' => {
+        'communicator' => 'winrm',
+      },
     }
   end
 
@@ -168,6 +171,32 @@ describe ConfigBuilder::Filter::Roles do
         ]
 
         expect(filtered_vm['provisioners']).to eq expected_prov
+      end
+    end
+
+    context 'when vm configuration overlaps with roles' do
+      let(:vms) do
+        [{
+          'name'         => 'master',
+          'roles'        => [ 'shell-provisioner', 'windows' ],
+          'communicator' => 'ssh',
+          'provisioners' => [
+            {'type' => 'foo', 'parameter' => 'bar', }
+          ],
+        }]
+      end
+
+      it 'preserves single_keys set on the vm' do
+        expect(filtered_vm['communicator']).to eq 'ssh'
+      end
+
+      it 'merges array_keys set on the vm last' do
+        expected_prov = {
+          'type'      => 'foo',
+          'parameter' => 'bar',
+        }
+
+        expect(filtered_vm['provisioners'].last).to eq expected_prov
       end
     end
 


### PR DESCRIPTION
Configuration set in roles was treated with a higher level of specificity than
configuration set on VMs. This means that values explicitly set by VM
configuration would be overwritten by roles and provisioners set by roles would
run after provisioners set directly on the VM. This behavior made it difficult
to override roles with explicit configuration or write VM-specific provisioners
that take advantage of shared configuration laid down by role provisioners.

This patch re-factors the roles provisioner such that values set directly on
VMs override values set on roles. For example, the following VM will now use
`ssh` to communicate instead of the `winrm` set by the role:

    ---
    vms:

      - name: some-windows-vm
        communicator: ssh
        roles:
          - windows

    roles:

      windows:
        communicator: winrm

Also, the provisioner set on the following VM will now run after the provisioner
set by the role, instead of before it:

    ---
    vms:

      - name: some-vm
        provisioners:
          - type: shell
            inline: /some-command that-requires networking
        roles:
          - setup

    roles:

      setup:
        provisioners:
          - type: shell
            inline: /some-command that-configures networking