### PR TITLE
Add primary option

### DIFF
--- a/lib/config_builder/model/vm.rb
+++ b/lib/config_builder/model/vm.rb
@@ -93,6 +93,12 @@ class ConfigBuilder::Model::VM < ConfigBuilder::Model::Base
   #   start.
   def_model_option :autostart
 
+  # @!attribute [rw] primary
+  #   @return [Boolean] If true, the box will be the default machine used when
+  #   a specific machine in a multi-machine environment is not specified.
+  #   If false, vagrant must be given the box name explicitly for some commands.
+  def_model_option :primary
+
   # @!attribute [rw] allowed_synced_folder_types
   #   @return [Array<String>]
   def_model_attribute :allowed_synced_folder_types

--- a/spec/integration/vagrant/vm_config_spec.rb
+++ b/spec/integration/vagrant/vm_config_spec.rb
@@ -22,7 +22,7 @@ describe 'Vagrant Integration: ConfigBuilder::Model::VM' do
     let(:config_data) {
       {'vms' =>
         [
-          {'name' => 'machine1'},
+          {'name' => 'machine1', 'primary' => true},
           {'name' => 'machine2', 'autostart' => false},
         ]
       }
@@ -38,6 +38,12 @@ describe 'Vagrant Integration: ConfigBuilder::Model::VM' do
       test_vm = subject.defined_vms[:machine2]
 
       expect(test_vm.options[:autostart]).to be_false
+    end
+
+    it 'sets the primary option when defining machines' do
+      test_vm = subject.defined_vms[:machine1]
+
+      expect(test_vm.options[:primary]).to be_true
     end
   end
 


### PR DESCRIPTION
This patch add support for the primary option in a multo-machine
configuration. See https://www.vagrantup.com/docs/multi-machine/